### PR TITLE
common: fdt_support: Fix MAC address handover to kernel for the iwg22m

### DIFF
--- a/common/fdt_support.c
+++ b/common/fdt_support.c
@@ -472,7 +472,7 @@ void fdt_fixup_ethernet(void *fdt)
 		do_fixup_by_path(fdt, path, "local-mac-address",
 				&mac_addr, 6, 1);
 #elif defined(CONFIG_IWG22M)
-sprintf(enet, "eth1");
+sprintf(enet, "ethernet0");
         path = fdt_getprop(fdt, node, enet, NULL);
                 if (!path) {
                         debug("No alias for %s\n", enet);


### PR DESCRIPTION
The DT for the iwg22m uses alias "ethernet0" for the ethernet card,
therefore fix this with the bootloader to make the kernel use the
same MAC address the bootloader is using.

Signed-off-by: Patryk Mungai Ndungu <patryk.mungai-ndungu.kx@renesas.com>